### PR TITLE
Introduce building for multiple architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,11 @@ FROM debian:9
 
 WORKDIR /app
 
+ARG ARCH
 # FIXME: docker can't use the cache for HTTP resources it seems, so the build is
 # long. I usually use a local copy and modify the dockerfile, but a better way
 # should be used?
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.14.3/bin/linux/amd64/kubectl /usr/local/bin
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.14.3/bin/linux/$ARCH/kubectl /usr/local/bin
 
 ADD run worker-host-endpoint.yaml.tmpl /app/
 ADD run vpn-host-endpoint.yaml.tmpl /app/

--- a/README.md
+++ b/README.md
@@ -8,3 +8,21 @@ Packet specific (the script uses "bond0" as the interface name).
 Also, another important consideration is that since a node start till the policy
 is applied, the node should not be exposed. This is not covered by this
 controller.
+
+Building
+========
+
+Depending on your architecture you would use one of the commands:
+
+```
+ARCH=amd64 docker build -t kinvolk/calico-hostendpoint-controller:v0.0.2-amd64 --build-arg ARCH . && docker push kinvolk/calico-hostendpoint-controller:v0.0.2-amd64
+ARCH=arm64 docker build -t kinvolk/calico-hostendpoint-controller:v0.0.2-arm64 --build-arg ARCH . && docker push kinvolk/calico-hostendpoint-controller:v0.0.2-arm64
+```
+
+When all images are build on the respective architectures and published they can be combined through a manifest:
+```
+docker manifest create kinvolk/calico-hostendpoint-controller:v0.0.2 --amend kinvolk/calico-hostendpoint-controller:v0.0.2-amd64 --amend kinvolk/calico-hostendpoint-controller:v0.0.2-arm64
+docker manifest annotate kinvolk/calico-hostendpoint-controller:v0.0.2 kinvolk/calico-hostendpoint-controller:v0.0.2-amd64 --arch=amd64 --os=linux
+docker manifest annotate kinvolk/calico-hostendpoint-controller:v0.0.2 kinvolk/calico-hostendpoint-controller:v0.0.2-arm64 --arch=arm64 --os=linux
+docker manifest push kinvolk/calico-hostendpoint-controller:v0.0.2
+```

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       serviceAccountName: calico-host-endpoint-controller
       containers:
-      - image: quay.io/kinvolk/calico-endpoint-controller:v0.0.2
+      - image: kinvolk/calico-endpoint-controller:v0.0.2
         name: calico-endpoint-controller
         volumeMounts:
         - mountPath: /tmp/


### PR DESCRIPTION
Only amd64 was supported because the architecture was hardcoded in the kubectl URL. This patch introduces a build environment variable to specify which architecture should be used.