### PR TITLE
Update to k8s v1.16.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG ARCH
 # FIXME: docker can't use the cache for HTTP resources it seems, so the build is
 # long. I usually use a local copy and modify the dockerfile, but a better way
 # should be used?
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.14.3/bin/linux/$ARCH/kubectl /usr/local/bin
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.16.2/bin/linux/$ARCH/kubectl /usr/local/bin
 
 ADD run worker-host-endpoint.yaml.tmpl /app/
 ADD run vpn-host-endpoint.yaml.tmpl /app/

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       serviceAccountName: calico-host-endpoint-controller
       containers:
-      - image: kinvolk/calico-endpoint-controller:v0.0.2
+      - image: kinvolk/calico-hostendpoint-controller:v0.0.3
         name: calico-endpoint-controller
         volumeMounts:
         - mountPath: /tmp/

--- a/run
+++ b/run
@@ -30,7 +30,7 @@ function get_workers_names() {
 
 	# TODO: simplify this command, make sure each node name is in a new line
 	#kubectl get nodes -l node-role.kubernetes.io/node -o jsonpath="{.items[*].metadata.name}"
-	kubectl get nodes -l node-role.kubernetes.io/node -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+	kubectl get nodes -l node.kubernetes.io/node -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
 }
 
 function create_endpoint_yaml() {


### PR DESCRIPTION
This PR updates the controller following https://github.com/kinvolk/terraform-render-bootkube/pull/23.

Summary of changes:

- Fix the label used by the controller script to select worker nodes.
- Update `kubectl` to `v1.16.2`.